### PR TITLE
fix: enable navbar navigation on all pages

### DIFF
--- a/src/sections/Header.tsx
+++ b/src/sections/Header.tsx
@@ -2,19 +2,29 @@
 
 import Image from 'next/image';
 import MenuIcon from '../../public/assets/menu.svg';
-import { useState } from 'react';
+import { useState, MouseEvent } from 'react';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faEnvelope, faMapMarkerAlt, faPhone } from "@fortawesome/free-solid-svg-icons";
-
-const scrollToSection = (id: string) => {
-  const section = document.getElementById(id);
-  if (section) {
-    section.scrollIntoView({ behavior: 'smooth', block: 'start' });
-  }
-};
+import Link from "next/link";
+import { usePathname } from "next/navigation";
 
 export const Header = () => {
   const [isNavOpen, setIsNavOpen] = useState(false);
+  const pathname = usePathname();
+
+  const handleNavigation = (
+    e: MouseEvent<HTMLAnchorElement>,
+    id: string
+  ) => {
+    if (pathname === "/") {
+      e.preventDefault();
+      const section = document.getElementById(id);
+      if (section) {
+        section.scrollIntoView({ behavior: "smooth", block: "start" });
+      }
+    }
+    setIsNavOpen(false);
+  };
 
   const toggleNav = () => {
     setIsNavOpen(!isNavOpen);
@@ -58,10 +68,10 @@ export const Header = () => {
             </div>
             {/* Desktop Navbar */}
             <nav className="hidden md:flex md:ml-6 gap-6 text-black/60 items-center">
-              <button onClick={() => scrollToSection('home')}>Acceuil</button>
-              <button onClick={() => scrollToSection('services')}>Services</button>
-              <button onClick={() => scrollToSection('objectifs')}>Objectifs</button>
-              <button onClick={() => scrollToSection('contact')}>Contact</button>
+              <Link href="/#home" onClick={(e) => handleNavigation(e, 'home')}>Acceuil</Link>
+              <Link href="/#services" onClick={(e) => handleNavigation(e, 'services')}>Services</Link>
+              <Link href="/#objectifs" onClick={(e) => handleNavigation(e, 'objectifs')}>Objectifs</Link>
+              <Link href="/#contact" onClick={(e) => handleNavigation(e, 'contact')}>Contact</Link>
               <a
                 href="https://www.facebook.com/profile.php?id=61568758889313"
                 target="_blank"
@@ -77,10 +87,10 @@ export const Header = () => {
           {/* Mobile Navbar */}
           {isNavOpen && (
             <nav className="md:hidden mt-4 bg-white shadow-md rounded-lg p-4 flex flex-col gap-4">
-              <button onClick={() => scrollToSection('home')} className="text-black">Acceuil</button>
-              <button onClick={() => scrollToSection('services')} className="text-black">Services</button>
-              <button onClick={() => scrollToSection('objectifs')} className="text-black">Objectifs</button>
-              <button onClick={() => scrollToSection('contact')} className="text-black">Contact</button>
+              <Link href="/#home" onClick={(e) => handleNavigation(e, 'home')} className="text-black">Acceuil</Link>
+              <Link href="/#services" onClick={(e) => handleNavigation(e, 'services')} className="text-black">Services</Link>
+              <Link href="/#objectifs" onClick={(e) => handleNavigation(e, 'objectifs')} className="text-black">Objectifs</Link>
+              <Link href="/#contact" onClick={(e) => handleNavigation(e, 'contact')} className="text-black">Contact</Link>
               <a
                 href="https://www.facebook.com/profile.php?id=61568758889313"
                 target="_blank"


### PR DESCRIPTION
## Summary
- allow navbar links to navigate back to homepage sections from any page
- replace buttons with `Link` to prevent hydration mismatches across routes

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_688e03385efc8329b2d8bffacb073886